### PR TITLE
Saving results to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,34 @@ $ pip install llm-profile[graph]
 
 matplotlib isn't installed by default to keep the dependencies for this plugin smaller.
 
+### Saving results
+
+You can save the benchmark results, including the text from each prompt to a YAML file using the `--output` option:
+
+```bash
+$ llm benchmark --output results.yaml
+```
+
+All of the timing data for each request as well as the text response will be saved in the YAML file:
+
+```yaml
+GPT-5-chat (Azerbaijan):
+- chunks_per_sec: 19.549590468140675
+  length_of_response: 34
+  model_name: GPT-5-chat (Azerbaijan)
+  n_chunks: 9
+  text: The capital of Azerbaijan is Baku.
+  time_to_first_chunk: 0.36127520000445656
+  total_time: 0.46036770001228433
+- chunks_per_sec: 20.64352283058553
+  length_of_response: 34
+  model_name: GPT-5-chat (Azerbaijan)
+  n_chunks: 9
+  text: The capital of Azerbaijan is Baku.
+  time_to_first_chunk: 0.3545127999968827
+  total_time: 0.43597210000734776
+```
+
 ### Test Plans
 
 Instead of providing tests and scenarios on the command line you can provide a YAML file with the benchmark plan:

--- a/llm_profile.py
+++ b/llm_profile.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import click
 import llm
+import yaml
 from pydantic import BaseModel
 from rich.box import HEAVY_HEAD, MARKDOWN
 from rich.progress import track
@@ -28,6 +29,7 @@ class BenchmarkData(BaseModel):
     length_of_response: int
     n_chunks: int = 1
     chunks_per_sec: float = 0.0
+    text: str = ""
 
 
 class TestModel(BaseModel):
@@ -101,6 +103,7 @@ def register_commands(cli):
     @click.option("--markdown", help="Use markdown table format", is_flag=True)
     @click.option("-g", "--graph", help="Save a graph of the results to the file path provided", type=str)
     @click.option("-p", "--plan", help="Path to a test plan YAML file", type=str, required=False)
+    @click.option("--output", help="Path to a YAML file containing the results", type=str, required=False)
     @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
     @click.option("--no-repeat-first", is_flag=True, help="Do not repeat the first test")
     @click.option(
@@ -121,6 +124,7 @@ def register_commands(cli):
         options: tuple[tuple[str, str], ...],
         graph: str,
         plan: str,
+        output: str,
         verbose: bool,
         no_repeat_first: bool,
     ):
@@ -151,6 +155,13 @@ def register_commands(cli):
             plot_stats_boxplots(stats, save_path=graph)
             if verbose:
                 console.print(f"Saved plot as {graph}")
+
+        if output:
+            result_stats = {k.name: [r.model_dump() for r in v] for k, v in stats.items()}
+            with open(output, "w") as f:
+                yaml.dump(result_stats, f)
+            if verbose:
+                console.print(f"Saved results as {output}")
 
 
 def execute_test(
@@ -210,6 +221,7 @@ def execute_test(
         length_of_response=len(text),
         n_chunks=n_chunks,
         chunks_per_sec=n_chunks / total_time if total_time > 0 else 0,
+        text=text,
     )
 
 


### PR DESCRIPTION
### Saving results

You can save the benchmark results, including the text from each prompt to a YAML file using the `--output` option:

```bash
$ llm benchmark --output results.yaml
```

All of the timing data for each request as well as the text response will be saved in the YAML file:

```yaml
GPT-5-chat (Azerbaijan):
- chunks_per_sec: 19.549590468140675
  length_of_response: 34
  model_name: GPT-5-chat (Azerbaijan)
  n_chunks: 9
  text: The capital of Azerbaijan is Baku.
  time_to_first_chunk: 0.36127520000445656
  total_time: 0.46036770001228433
- chunks_per_sec: 20.64352283058553
  length_of_response: 34
  model_name: GPT-5-chat (Azerbaijan)
  n_chunks: 9
  text: The capital of Azerbaijan is Baku.
  time_to_first_chunk: 0.3545127999968827
  total_time: 0.43597210000734776
```
